### PR TITLE
Improves cl-arguments, file output, testing (resolves #2)

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,7 +101,8 @@ def setup_args():
     parser.add_argument(
         "--output",
         default=None,
-        help="Enter a file path to save results to a .csv file."
+        help="Enter a file path to save results to a .csv file.",
+        choices=["csv", "txt", "json", "xlsx"],
     )
     parser.add_argument(
         "--start_date",
@@ -117,6 +118,7 @@ def setup_args():
         "--frequency",
         default=None,
         help="Can limit snapshots to remove duplicates (1 per hr, day, month, etc). Defaults to None.",
+        choices=["yearly", "monthly", "daily", "hourly"],
     )
     parser.add_argument(
         "--limit",

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import asyncio
 import argparse
 from osint_ga.utils import (
     get_limit_from_frequency,
+    get_14_digit_timestamp,
     COLLAPSE_OPTIONS,
 )
 
@@ -22,10 +23,10 @@ async def main(args):
 
     # Update dates to 14-digit format
     if args.start_date:
-        print(args.start_date)
+        args.start_date = get_14_digit_timestamp(args.start_date)
 
     if args.end_date:
-        print(args.end_date)
+        args.end_date = get_14_digit_timestamp(args.end_date)
 
     # Gets appropriate limit for given frequency & converts frequency to collapse option
     if args.frequency:
@@ -72,7 +73,7 @@ def setup_args():
     )
     parser.add_argument(
         "--start_date",
-        default="20121001000000",
+        default="01/10/2012:00:00",
         help="Start date for time range (dd/mm/YYYY:HH:MM) Defaults to 01/10/2012:00:00, when UA codes were adopted.",
     )
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 import aiohttp
-import asyncio
 import argparse
+import asyncio
 from osint_ga.utils import (
     get_limit_from_frequency,
     get_14_digit_timestamp,
@@ -16,6 +16,7 @@ from osint_ga.output import (
     write_output,
 )
 
+
 async def main(args):
     """Main function. Runs get_analytics_codes() and prints results.
 
@@ -25,10 +26,11 @@ async def main(args):
     Returns:
         None
     """
-    # If input file is provided, read urls from file
-    if args.input:
+
+    # If input_file is provided, read urls from file path
+    if args.input_file:
         try:
-            with open(args.input, "r") as f:
+            with open(args.input_file, "r") as f:
                 args.urls = f.read().splitlines()
         except FileNotFoundError:
             print("File not found. Please enter a valid file path.")
@@ -47,13 +49,15 @@ async def main(args):
 
     # Gets appropriate limit for given frequency & converts frequency to collapse option
     if args.frequency:
-        args.limit = get_limit_from_frequency(
-            frequency=args.frequency,
-            start_date=args.start_date,
-            end_date=args.end_date,
-        ) + 1
+        args.limit = (
+            get_limit_from_frequency(
+                frequency=args.frequency,
+                start_date=args.start_date,
+                end_date=args.end_date,
+            )
+            + 1
+        )
         args.frequency = COLLAPSE_OPTIONS[args.frequency]
-
 
     async with aiohttp.ClientSession() as session:
         results = await get_analytics_codes(
@@ -87,11 +91,12 @@ def setup_args():
 
     parser = argparse.ArgumentParser()
 
+    # Argparse group to prevent user from entering both --input_file and --urls
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
-        "--input",
+        "--input_file",
         default=None,
-        help="Enter a file path to a list of urls in a text or .csv file."
+        help="Enter a file path to a list of urls in a readable file type (e.g. .txt, .csv, .md)",
     )
     group.add_argument(
         "--urls",
@@ -100,8 +105,8 @@ def setup_args():
     )
     parser.add_argument(
         "--output",
-        default=None,
-        help="Enter a file path to save results to a .csv file.",
+        default="json",
+        help="Enter an output type to write results to file. Defaults to json.",
         choices=["csv", "txt", "json", "xlsx"],
     )
     parser.add_argument(

--- a/main.py
+++ b/main.py
@@ -20,6 +20,14 @@ async def main(args):
         None
     """
 
+    # Update dates to 14-digit format
+    if args.start_date:
+        print(args.start_date)
+
+    if args.end_date:
+        print(args.end_date)
+
+    # Gets appropriate limit for given frequency & converts frequency to collapse option
     if args.frequency:
         args.limit = get_limit_from_frequency(
             frequency=args.frequency,
@@ -27,6 +35,7 @@ async def main(args):
             end_date=args.end_date,
         ) + 1
         args.frequency = COLLAPSE_OPTIONS[args.frequency]
+
 
     async with aiohttp.ClientSession() as session:
         results = await get_analytics_codes(
@@ -64,12 +73,12 @@ def setup_args():
     parser.add_argument(
         "--start_date",
         default="20121001000000",
-        help="Start date for time range. Defaults to Oct 1, 2012, when UA codes were adopted.",
+        help="Start date for time range (dd/mm/YYYY:HH:MM) Defaults to 01/10/2012:00:00, when UA codes were adopted.",
     )
     parser.add_argument(
         "--end_date",
         default=None,
-        help="End date for time range. Defaults to None.",
+        help="End date for time range (dd/mm/YYYY:HH:MM). Defaults to None.",
     )
     parser.add_argument(
         "--frequency",

--- a/osint_ga/codes.py
+++ b/osint_ga/codes.py
@@ -1,5 +1,6 @@
-import re
 from bs4 import BeautifulSoup
+import re
+
 
 def get_UA_code(html):
     """Returns UA codes (w/o duplicates) from given html, or None if not found.
@@ -11,6 +12,7 @@ def get_UA_code(html):
         ["UA-12345678-1", "UA-12345678-2", ...]
     """
 
+    # Only search for codes in script tags
     script_tags = BeautifulSoup(html, "html.parser").find_all("script")
 
     # Regex pattern to find UA codes
@@ -40,6 +42,7 @@ def get_GA_code(html):
         ["G-1234567890", "G-1234567891", ...]
     """
 
+    # Only search for codes in script tags
     script_tags = BeautifulSoup(html, "html.parser").find_all("script")
 
     # Regex pattern to find GA codes
@@ -67,6 +70,7 @@ def get_GTM_code(html):
         ["GTM-1234567890", "GTM-1234567891", ...]
     """
 
+    # Only search for codes in script tags
     script_tags = BeautifulSoup(html, "html.parser").find_all("script")
 
     # This pattern

--- a/osint_ga/codes.py
+++ b/osint_ga/codes.py
@@ -66,6 +66,7 @@ def get_GTM_code(html):
     """Returns GTM codes (w/o duplicates) from given html, or None if not found.
     Args:
         html (str): Raw html.
+
     Returns:
         ["GTM-1234567890", "GTM-1234567891", ...]
     """

--- a/osint_ga/output.py
+++ b/osint_ga/output.py
@@ -133,8 +133,8 @@ def format_archived_codes(archived_codes):
     results = []
     idx = 1
 
-    for code, range in archived_codes.items():
-        results.append(f"{idx}. {code} ({range['first_seen']} - {range['last_seen']})")
+    for code, timeframe in archived_codes.items():
+        results.append(f"{idx}. {code} ({timeframe['first_seen']} - {timeframe['last_seen']})")
         idx += 1
 
     return "\n\n".join(results)
@@ -206,8 +206,9 @@ def format_active(list):
     Example:
         ["Current (at https://www.example.com)", "2019-01-01 - 2020-01-01 (at https://www.example.com)"]
             ->
-        "1. Current (at https://www.example.com)\n
+        "1. Current (at https://www.example.com)\n\n
          2. 2019-01-01 - 2020-01-01 (at https://www.example.com)"
 
     """
+
     return "\n\n".join(f"{i + 1}. {item}" for i, item in enumerate(list))

--- a/osint_ga/output.py
+++ b/osint_ga/output.py
@@ -1,0 +1,87 @@
+from datetime import datetime
+import json
+import os
+import pandas as pd
+
+
+def init_output(type):
+    """Creates output directory and initializes empty output file.
+
+    Args:
+        type (str): csv/txt/json.
+
+    Returns:
+        None
+    """
+
+    valid_types = ["csv", "txt", "json"]
+    if type not in valid_types:
+        raise ValueError(f"Invalid output type: {type}. Please use csv, txt, or json.")
+
+    # Create output directory if it doesn't exist
+    if not os.path.exists("output"):
+        os.makedirs("output")
+
+    # Get current date and time for file name
+    file_name = datetime.now().strftime("%d-%m-%Y(%H:%M:%S)")
+
+    # Create output file
+
+    with open(os.path.join("./output", f"{file_name}.{type}"), "w") as f:
+        pass
+
+    return "./output/" + f"{file_name}.{type}"
+
+
+def write_output(output_file, output_type, results):
+    """Writes results to the correct output file in json, csv or txt.
+
+    Args:
+        output_file (str): Path to output file.
+        output_type (str): csv/txt/json.
+        results (dict): Results from scraper.
+
+    Returns:
+        None
+    """
+
+    # Determine output type
+    if output_type == "json":
+        with open(output_file, "w") as f:
+            json.dump(results, f, indent=4)
+
+    if output_type == "txt":
+        with open(output_file, "w") as f:
+            json.dump(results, f, indent=4)
+
+    if output_type == "csv":
+        # make dataframes in pandas
+        # url_df = pd.DataFrame(
+        #     columns=[
+        #         "url",
+        #         "UA_Code",
+        #         "GA_Code",
+        #         "GTM_Code",
+        #         "Archived_UA_Codes",
+        #         "Archived_GA_Codes",
+        #         "Archived_GTM_Codes",
+        #     ]
+        # )
+
+        url_list = []
+
+        for item in results:
+            for url, info in item.items():
+                url_list.append({
+                    "url": url,
+                    "UA_Code": info["current_UA_code"],
+                    "GA_Code": info["current_GA_code"],
+                    "GTM_Code": info["current_GTM_code"],
+                    "Archived_UA_Codes": info["archived_UA_codes"],
+                    "Archived_GA_Codes": info["archived_GA_codes"],
+                    "Archived_GTM_Codes": info["archived_GTM_codes"],
+                })
+
+        url_df = pd.DataFrame(url_list)
+
+        url_df.to_csv(output_file, index=False)

--- a/osint_ga/output.py
+++ b/osint_ga/output.py
@@ -27,13 +27,14 @@ def init_output(type):
     # Get current date and time for file name
     file_name = datetime.now().strftime("%d-%m-%Y(%H:%M:%S)")
 
-    # Create output file
+    # Create empty output file if type is not csv and return filename
     if type not in ["csv"]:
         with open(os.path.join("./output", f"{file_name}.{type}"), "w") as f:
             pass
 
         return "./output/" + f"{file_name}.{type}"
 
+    # If csv, create separate files for urls and codes and return filename
     with open(os.path.join("./output", f"{file_name}_urls.{type}"), "w") as f:
         pass
 
@@ -92,6 +93,7 @@ def get_urls_df(results):
     Returns:
         urls_df (pd.DataFrame): Pandas dataframe of results.
     """
+
     url_list = []
 
     for item in results:
@@ -102,20 +104,47 @@ def get_urls_df(results):
                     "UA_Code": info["current_UA_code"],
                     "GA_Code": info["current_GA_code"],
                     "GTM_Code": info["current_GTM_code"],
-                    "Archived_UA_Codes": info["archived_UA_codes"],
-                    "Archived_GA_Codes": info["archived_GA_codes"],
-                    "Archived_GTM_Codes": info["archived_GTM_codes"],
+                    "Archived_UA_Codes": format_archived_codes(
+                        info["archived_UA_codes"]
+                    ),
+                    "Archived_GA_Codes": format_archived_codes(
+                        info["archived_GA_codes"]
+                    ),
+                    "Archived_GTM_Codes": format_archived_codes(
+                        info["archived_GTM_codes"]
+                    ),
                 }
             )
 
     return pd.DataFrame(url_list)
 
 
+def format_archived_codes(archived_codes):
+    """Helper function to flatten archived codes and format them into a single string where
+    each item is numbered and separated by a newline.
+
+    Args:
+        archived_codes (dict): Dictionary of archived codes.
+
+    Returns:
+        str: Formatted string.
+    """
+
+    results = []
+    idx = 1
+
+    for code, range in archived_codes.items():
+        results.append(f"{idx}. {code} ({range['first_seen']} - {range['last_seen']})")
+        idx += 1
+
+    return "\n\n".join(results)
+
+
 def get_codes_df(results):
     """Converts the result dictionary into a Pandas dataframe and returns it.
 
     Args:
-        dict: Results from scraper.
+        results (dict): Results from scraper.
 
     Returns:
         codes_df (pd.DataFrame): Pandas dataframe of results.

--- a/osint_ga/utils.py
+++ b/osint_ga/utils.py
@@ -70,7 +70,29 @@ def get_limit_from_frequency(frequency, start_date, end_date):
         return int(total_hours + 1)
 
     # Raise error if frequency none of the above options
-    raise ValueError(f"Invalid frequency: {frequency}. Please use hourly, daily, monthly, or yearly.")
+    raise ValueError(
+        f"Invalid frequency: {frequency}. Please use hourly, daily, monthly, or yearly."
+    )
+
+
+def get_date_from_timestamp(timestamp):
+    """Takes a 14-digit timestamp (YYYYmmddHHMMSS) and returns a date (dd/mm/YYYY:HH:MM).
+
+    Args:
+        timestamp (str): 14-digit timestamp (YYYYmmddHHMMSS)
+
+    Returns:
+        str: Date in format dd/mm/YYYY:HH:MM
+
+    Example: 20121001000000 -> 01/10/2012:00:00
+    """
+
+    # convert timestamp to datetime object
+    date = datetime.strptime(timestamp, "%Y%m%d%H%M%S")
+
+    # convert datetime object to date
+    return date.strftime("%d/%m/%Y:%H:%M")
+
 
 def get_14_digit_timestamp(date):
     """Takes a date (dd/mm/YYYY:HH:MM) and converts it to a 14-digit timestamp (YYYYmmddHHMMSS).
@@ -92,6 +114,7 @@ def get_14_digit_timestamp(date):
 
     # Convert datetime object to 14-digit timestamp
     return date.strftime("%Y%m%d%H%M%S")
+
 
 async def get_snapshot_timestamps(
     session,
@@ -227,29 +250,29 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
                     for code in UA_codes:
                         if code not in results["UA_codes"]:
                             results["UA_codes"][code] = {}
-                            results["UA_codes"][code]["first_seen"] = timestamp
-                            results["UA_codes"][code]["last_seen"] = timestamp
+                            results["UA_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
+                            results["UA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
                         if code in results["UA_codes"]:
-                            results["UA_codes"][code]["last_seen"] = timestamp
+                            results["UA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
                     for code in GA_codes:
                         if code not in results["GA_codes"]:
                             results["GA_codes"][code] = {}
-                            results["GA_codes"][code]["first_seen"] = timestamp
-                            results["GA_codes"][code]["last_seen"] = timestamp
+                            results["GA_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
+                            results["GA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
                         if code in results["GA_codes"]:
-                            results["GA_codes"][code]["last_seen"] = timestamp
+                            results["GA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
                     for code in GTM_codes:
                         if code not in results["GTM_codes"]:
                             results["GTM_codes"][code] = {}
-                            results["GTM_codes"][code]["first_seen"] = timestamp
-                            results["GTM_codes"][code]["last_seen"] = timestamp
+                            results["GTM_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
+                            results["GTM_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
                         if code in results["GTM_codes"]:
-                            results["GTM_codes"][code]["last_seen"] = timestamp
+                            results["GTM_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
 
             # TODO: Add better/clearer error handling here
             except Exception as e:

--- a/osint_ga/utils.py
+++ b/osint_ga/utils.py
@@ -1,8 +1,7 @@
 import asyncio
-import re
-
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+import re
 
 from osint_ga.codes import get_UA_code, get_GA_code, get_GTM_code
 
@@ -24,7 +23,7 @@ COLLAPSE_OPTIONS = {
 
 
 def get_limit_from_frequency(frequency, start_date, end_date):
-    """Returns an appropriate limit for a given frequency.
+    """Returns an appropriate limit for a given frequency to be used w/ the CDX api.
 
     Args:
         frequency (str): Frequency (hourly, daily, monthly, yearly)
@@ -32,7 +31,7 @@ def get_limit_from_frequency(frequency, start_date, end_date):
         end_date (str): 14-digit timestamp for end of range
 
     Returns:
-        int: Limit
+        int: Limit for CDX api
     """
 
     # Get start date as datetime object or raise error if not provided
@@ -227,6 +226,9 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
         base_url (str): Base url for archive.org snapshot.
         timestamp (str): 14-digit timestamp.
         results (dict): Dictionary to add codes to (inherited from get_codes_from_snapshots()).
+
+    Returns:
+        None
     """
 
     # Use semaphore to limit number of concurrent requests
@@ -250,29 +252,47 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
                     for code in UA_codes:
                         if code not in results["UA_codes"]:
                             results["UA_codes"][code] = {}
-                            results["UA_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
-                            results["UA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["UA_codes"][code][
+                                "first_seen"
+                            ] = get_date_from_timestamp(timestamp)
+                            results["UA_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
                         if code in results["UA_codes"]:
-                            results["UA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["UA_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
                     for code in GA_codes:
                         if code not in results["GA_codes"]:
                             results["GA_codes"][code] = {}
-                            results["GA_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
-                            results["GA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["GA_codes"][code][
+                                "first_seen"
+                            ] = get_date_from_timestamp(timestamp)
+                            results["GA_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
                         if code in results["GA_codes"]:
-                            results["GA_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["GA_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
                     for code in GTM_codes:
                         if code not in results["GTM_codes"]:
                             results["GTM_codes"][code] = {}
-                            results["GTM_codes"][code]["first_seen"] = get_date_from_timestamp(timestamp)
-                            results["GTM_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["GTM_codes"][code][
+                                "first_seen"
+                            ] = get_date_from_timestamp(timestamp)
+                            results["GTM_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
                         if code in results["GTM_codes"]:
-                            results["GTM_codes"][code]["last_seen"] = get_date_from_timestamp(timestamp)
+                            results["GTM_codes"][code][
+                                "last_seen"
+                            ] = get_date_from_timestamp(timestamp)
 
             # TODO: Add better/clearer error handling here
             except Exception as e:

--- a/osint_ga/utils.py
+++ b/osint_ga/utils.py
@@ -72,6 +72,27 @@ def get_limit_from_frequency(frequency, start_date, end_date):
     # Raise error if frequency none of the above options
     raise ValueError(f"Invalid frequency: {frequency}. Please use hourly, daily, monthly, or yearly.")
 
+def get_14_digit_timestamp(date):
+    """Takes a date (dd/mm/YYYY:HH:MM) and converts it to a 14-digit timestamp (YYYYmmddHHMMSS).
+
+    Args:
+        date (str): Date in format dd/mm/YYYY:HH:MM
+
+    Returns:
+        str: 14-digit timestamp (YYYYmmddHHMMSS)
+
+    Example: 01/10/2012:00:00 -> 20121001000000
+    """
+
+    # Convert date to datetime object
+    try:
+        date = datetime.strptime(date, "%d/%m/%Y:%H:%M")
+    except ValueError:
+        date = datetime.strptime(date, "%d/%m/%Y")
+
+    # Convert datetime object to 14-digit timestamp
+    return date.strftime("%Y%m%d%H%M%S")
+
 async def get_snapshot_timestamps(
     session,
     url,
@@ -93,13 +114,6 @@ async def get_snapshot_timestamps(
     Returns:
         Array of timestamps:
             ["20190101000000", "20190102000000", ...]
-
-    NOTE: The CDX params are a bit finnicky. It may be best to return a larger number of timestamps and then filter out the
-    ones we don't need. That would lead to longer load times, however. Main issues include:
-
-    - 'frequency' often breaks with other params. It is most reliable when paired with an exact limit (if getting years
-    since 2012, add a limit of 11 results)
-    - 'limit' breaks with frequency and start date if inverted to get most recent snapshots first.
     """
 
     # Default params get snapshots from url domain w/ 200 status codes only.

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+from osint_ga.output import (
+    init_output,
+    write_output,
+    get_codes_df,
+    get_urls_df,
+    format_archived_codes,
+    format_active,
+)
+
+
+class OutputTestCase(TestCase):
+    """Tests for output.py"""
+
+    def setUp(self):
+        """Create test data"""
+
+    def test_format_active(self):
+        """Does format_active convert list of "active" values from df into formatted string?"""
+
+        test_active_list = [
+            "Current (at https://www.example.com)",
+            "2019-01-01 - 2020-01-01 (at https://www.example.com)",
+            "2018-01-01 - 2019-01-01 (at https://www.example.com)",
+        ]
+
+        expected = (
+            "1. Current (at https://www.example.com)\n\n"
+            "2. 2019-01-01 - 2020-01-01 (at https://www.example.com)\n\n"
+            "3. 2018-01-01 - 2019-01-01 (at https://www.example.com)"
+        )
+
+        self.assertEqual(format_active(test_active_list), expected)
+        self.assertTrue(type(format_active(test_active_list)) is str)
+
+    def test_format_archived_codes(self):
+        """Does format_archived_codes convert dict of archived codes into formatted string?"""
+
+        archived_codes = {
+            "UA-21085468-1": {
+                "first_seen": "04/01/2014:04:02",
+                "last_seen": "03/01/2012:06:00",
+            },
+            "UA-113949143-1": {
+                "first_seen": "01/01/2019:19:39",
+                "last_seen": "01/01/2023:00:16",
+            },
+        }
+
+        expected = (
+            "1. UA-21085468-1 (04/01/2014:04:02 - 03/01/2012:06:00)\n\n"
+            "2. UA-113949143-1 (01/01/2019:19:39 - 01/01/2023:00:16)"
+        )
+
+        self.assertEqual(format_archived_codes(archived_codes), expected)
+        self.assertTrue(type(format_archived_codes(archived_codes)) is str)


### PR DESCRIPTION
This PR fleshes out several features, mainly:

- CLI arguments w/ argparser
- Writing to `.txt`, `.csv`, `.xlsx` and `.json` files
- Incorporated pandas for printing to `.csv` and `.xlsx` files
- Reading urls from files instead of terminal
- Expanded testing
- Better file organization.

## Changelog:

#### CLI arguments:
- Added `--file_input` which reads urls from text files. Mutually incompatible with `--urls`
- Added `--output`, which determines how results will be printed (defaults to `.json` + printing in terminal)
- Can now add start/end of time frame using dd/mm/YYYY:HH:MM timestamps
- Added more strict limits for several arguments, including `--frequency` and `--output`, to prevent errors.
- Improved hints in argparser

#### File writing:
- Added functionality to create `/output/` folder + print results to timestamped files in one of four filetypes.
- If a spreadsheet filetype is chosen, the output is sorted by url and by code and printed to two separate outputs (two files if `.csv`, two sheets of the same spreadsheet if `.xlsx`). This makes it easy to see all codes for a website or all websites sharing a common code. 

#### Tests:
- Added tests for basic formatting helper functions + init_output using mock.


