### PR TITLE
Inaccurate timestamps (fix #9)

### DIFF
--- a/osint_ga/async_utils.py
+++ b/osint_ga/async_utils.py
@@ -168,12 +168,8 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
                     for code in GA_codes:
                         if code not in results["GA_codes"]:
                             results["GA_codes"][code] = {}
-                            results["GA_codes"][code][
-                                "first_seen"
-                            ] = timestamp
-                            results["GA_codes"][code][
-                                "last_seen"
-                            ] = timestamp
+                            results["GA_codes"][code]["first_seen"] = timestamp
+                            results["GA_codes"][code]["last_seen"] = timestamp
 
                         if code in results["GA_codes"]:
                             if timestamp < results["GA_codes"][code]["first_seen"]:
@@ -184,12 +180,8 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
                     for code in GTM_codes:
                         if code not in results["GTM_codes"]:
                             results["GTM_codes"][code] = {}
-                            results["GTM_codes"][code][
-                                "first_seen"
-                            ] = timestamp
-                            results["GTM_codes"][code][
-                                "last_seen"
-                            ] = timestamp
+                            results["GTM_codes"][code]["first_seen"] = timestamp
+                            results["GTM_codes"][code]["last_seen"] = timestamp
 
                         if code in results["GTM_codes"]:
                             if timestamp < results["GTM_codes"][code]["first_seen"]:

--- a/osint_ga/async_utils.py
+++ b/osint_ga/async_utils.py
@@ -107,6 +107,16 @@ async def get_codes_from_snapshots(session, url, timestamps):
         for timestamp in timestamps
     ]
     await asyncio.gather(*tasks)
+
+    for code_type in results:
+        for code in results[code_type]:
+            results[code_type][code]["first_seen"] = get_date_from_timestamp(
+                results[code_type][code]["first_seen"]
+            )
+            results[code_type][code]["last_seen"] = get_date_from_timestamp(
+                results[code_type][code]["last_seen"]
+            )
+
     return results
 
 
@@ -131,7 +141,9 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
             try:
                 html = await response.text()
 
-                print("Retrieving codes from url: ", base_url.format(timestamp=timestamp))
+                print(
+                    "Retrieving codes from url: ", base_url.format(timestamp=timestamp)
+                )
 
                 if html:
                     # Get UA/GA codes from html
@@ -144,50 +156,52 @@ async def get_codes_from_single_timestamp(session, base_url, timestamp, results)
                     for code in UA_codes:
                         if code not in results["UA_codes"]:
                             results["UA_codes"][code] = {}
-                            results["UA_codes"][code][
-                                "first_seen"
-                            ] = get_date_from_timestamp(timestamp)
-                            results["UA_codes"][code][
-                                "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            results["UA_codes"][code]["first_seen"] = timestamp
+                            results["UA_codes"][code]["last_seen"] = timestamp
 
                         if code in results["UA_codes"]:
-                            results["UA_codes"][code][
-                                "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            if timestamp < results["UA_codes"][code]["first_seen"]:
+                                results["UA_codes"][code]["first_seen"] = timestamp
+                            if timestamp > results["UA_codes"][code]["last_seen"]:
+                                results["UA_codes"][code]["last_seen"] = timestamp
 
                     for code in GA_codes:
                         if code not in results["GA_codes"]:
                             results["GA_codes"][code] = {}
                             results["GA_codes"][code][
                                 "first_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            ] = timestamp
                             results["GA_codes"][code][
                                 "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            ] = timestamp
 
                         if code in results["GA_codes"]:
-                            results["GA_codes"][code][
-                                "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            if timestamp < results["GA_codes"][code]["first_seen"]:
+                                results["GA_codes"][code]["first_seen"] = timestamp
+                            if timestamp > results["GA_codes"][code]["last_seen"]:
+                                results["GA_codes"][code]["last_seen"] = timestamp
 
                     for code in GTM_codes:
                         if code not in results["GTM_codes"]:
                             results["GTM_codes"][code] = {}
                             results["GTM_codes"][code][
                                 "first_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            ] = timestamp
                             results["GTM_codes"][code][
                                 "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            ] = timestamp
 
                         if code in results["GTM_codes"]:
-                            results["GTM_codes"][code][
-                                "last_seen"
-                            ] = get_date_from_timestamp(timestamp)
+                            if timestamp < results["GTM_codes"][code]["first_seen"]:
+                                results["GTM_codes"][code]["first_seen"] = timestamp
+                            if timestamp > results["GTM_codes"][code]["last_seen"]:
+                                results["GTM_codes"][code]["last_seen"] = timestamp
 
             except Exception as e:
-                print(f"Error retrieving codes from {base_url.format(timestamp=timestamp)}: ", e)
+                print(
+                    f"Error retrieving codes from {base_url.format(timestamp=timestamp)}: ",
+                    e,
+                )
                 return None
 
         print("Finish gathering codes for: ", base_url.format(timestamp=timestamp))

--- a/osint_ga/scraper.py
+++ b/osint_ga/scraper.py
@@ -107,7 +107,7 @@ async def process_url(session, url, start_date, end_date, frequency, limit):
     curr_entry[url]["archived_GA_codes"] = archived_codes["GA_codes"]
     curr_entry[url]["archived_GTM_codes"] = archived_codes["GTM_codes"]
 
-    print("Finished retrieving updated codes for: ", url)
+    print("Finished retrieving archived codes for: ", url)
 
     return curr_entry
 


### PR DESCRIPTION
This PR fixes the inaccurate first/last seen timestamps. There is an extra check in place that only replaces a first/last seen timestamp if it is lesser/greater than the current value, so its irrelevant what order the async requests are processed. The 14-digit timestamps are converted to dates after `asyncio.gather()` runs each of the tasks. 