### PR TITLE
Add better rate limit protection (solves #19)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ You can also clone and download the repo from github and use the tool locally.
 
 3. Get a high-level overview:
     ```terminal
-    python main.py -h
+    python -m wayback_google_analytics.main.py -h
     ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/README.md
+++ b/README.md
@@ -227,27 +227,28 @@ Options list (run `wayback-google-analytics -h` to see in terminal):
 options:
   -h, --help            show this help message and exit
   -i INPUT_FILE, --input_file INPUT_FILE
-                        Enter a file path to a list of urls in a readable file
-                        type (e.g. .txt, .csv, .md)
+                        Enter a file path to a list of urls in a readable file type
+                        (e.g. .txt, .csv, .md)
   -u URLS [URLS ...], --urls URLS [URLS ...]
-                        Enter a list of urls separated by spaces to get their
-                        UA/GA codes (e.g. --urls https://www.google.com
+                        Enter a list of urls separated by spaces to get their UA/GA
+                        codes (e.g. --urls https://www.google.com
                         https://www.facebook.com)
   -o {csv,txt,json,xlsx}, --output {csv,txt,json,xlsx}
-                        Enter an output type to write results to file.
-                        Defaults to json.
+                        Enter an output type to write results to file. Defaults to
+                        json.
   -s START_DATE, --start_date START_DATE
-                        Start date for time range (dd/mm/YYYY:HH:MM) Defaults
-                        to 01/10/2012:00:00, when UA codes were adopted.
+                        Start date for time range (dd/mm/YYYY:HH:MM) Defaults to
+                        01/10/2012:00:00, when UA codes were adopted.
   -e END_DATE, --end_date END_DATE
-                        End date for time range (dd/mm/YYYY:HH:MM). Defaults
-                        to None.
+                        End date for time range (dd/mm/YYYY:HH:MM). Defaults to None.
   -f {yearly,monthly,daily,hourly}, --frequency {yearly,monthly,daily,hourly}
-                        Can limit snapshots to remove duplicates (1 per hr,
-                        day, month, etc). Defaults to None.
+                        Can limit snapshots to remove duplicates (1 per hr, day, month,
+                        etc). Defaults to None.
   -l LIMIT, --limit LIMIT
-                        Limits number of snapshots returned. Defaults to -100
-                        (most recent 100 snapshots).
+                        Limits number of snapshots returned. Defaults to -100 (most
+                        recent 100 snapshots).
+  -sc, --skip_current   Add this flag to skip current UA/GA codes when getting archived
+                        codes.
 
 ```
 
@@ -289,7 +290,15 @@ Ordered by code:
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+<!-- Limitations -->
+## Limitations & Rate Limits
 
+We recommend that you limit your list of urls to ~10 and your max snapshot limit to <500 during queries. While Wayback Google Analytics doesn't have any hardcoded limitations in regards to how many urls or snapshots you can request, large queries can cause 443 errors (rate limiting). Being rate limited can result in a temporary 5-10 minute ban from web.archive.org and the CDX api.
+
+The app currently uses `asyncio.Semaphore()` along with delays between requests, but large queries or operations that take a long time can still result in a 443. Use your judgment and break large queries into smaller, more manageable pieces if you find yourself getting rate limited.
+
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- CONTRIBUTING -->
 ## Contributing
@@ -324,8 +333,6 @@ If you have push access, follow these steps to trigger the GitHub workflow that 
 Distributed under the MIT License. See `LICENSE.txt` for more information.
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
-
-
 
 <!-- CONTACT -->
 ## Contact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wayback-google-analytics"
-version = "0.1.6"
+version = "0.2.0"
 description = "A tool for gathering current and historic google analytics ids from multiple websites"
 authors = ["Justin Clark <jclarksummit@gmail.com>"]
 license = "MIT"

--- a/tests/test_async_utils.py
+++ b/tests/test_async_utils.py
@@ -62,15 +62,10 @@ class AsyncUtilsTestCase(asynctest.TestCase):
     @patch("wayback_google_analytics.async_utils.get_UA_code")
     @patch("wayback_google_analytics.async_utils.get_GA_code")
     @patch("wayback_google_analytics.async_utils.get_GTM_code")
-    @patch("wayback_google_analytics.async_utils.sem", new_callable=MagicMock())
     async def test_get_codes_from_single_timestamp(
-        self, mock_sem, mock_GTM, mock_GA, mock_UA, mock_get
+        self, mock_GTM, mock_GA, mock_UA, mock_get
     ):
         """Does get_codes_from_single_timestamp return correct codes from a single archive.org snapshot?"""
-
-        # Mock semaphore
-        mock_sem.__aenter__.return_value = MagicMock()
-        mock_sem.__aexit__.return_value = MagicMock()
 
         # Mock the response from the server
         mock_response = MagicMock()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -89,6 +89,7 @@ class TestMain(unittest.TestCase):
             "daily",
             "--limit",
             "10",
+            "--skip_current",
         ]
         args = setup_args()
 
@@ -102,6 +103,7 @@ class TestMain(unittest.TestCase):
         self.assertEqual(args.end_date, "01/01/2013:12:00")
         self.assertEqual(args.frequency, "daily")
         self.assertEqual(args.limit, "10")
+        self.assertEqual(args.skip_current, True)
 
     def test_setup_args_valid_args_shorthand(self):
         """Does setup_args return args if valid args provided using shorthand commands?"""
@@ -120,6 +122,7 @@ class TestMain(unittest.TestCase):
             "daily",
             "-l",
             "10",
+            "-sc",
         ]
         args = setup_args()
 
@@ -133,3 +136,4 @@ class TestMain(unittest.TestCase):
         self.assertEqual(args.end_date, "01/01/2013:12:00")
         self.assertEqual(args.frequency, "daily")
         self.assertEqual(args.limit, "10")
+        self.assertEqual(args.skip_current, True)

--- a/wayback_google_analytics/main.py
+++ b/wayback_google_analytics/main.py
@@ -66,24 +66,38 @@ async def main(args):
         )
         args.frequency = COLLAPSE_OPTIONS[args.frequency]
 
-    semaphore = asyncio.Semaphore(15)
+    semaphore = asyncio.Semaphore(10)
 
-    async with semaphore:
-        async with aiohttp.ClientSession() as session:
-            results = await get_analytics_codes(
-                session=session,
-                urls=args.urls,
-                start_date=args.start_date,
-                end_date=args.end_date,
-                frequency=args.frequency,
-                limit=args.limit,
-                semaphore=semaphore,
-            )
-            print(results)
+    # Warn user if large request
+    if abs(int(args.limit)) > 500 or len(args.urls) > 9:
+        response = input(f"""Large requests can lead to being rate limited by archive.org.\n\n Current limit: {args.limit} (Recommended < 500) \n\n Current # of urls: {len(args.urls)} (Recommended < 10, unless limit < 50)
 
-    # handle printing the output
-    if args.output:
-        write_output(output_file, args.output, results)
+        Do you wish to proceed? (Yes/no)
+                         """)
+        if response.lower() not in ('yes', 'y'):
+            print("Request cancelled.")
+            exit()
+
+    try:
+        async with semaphore:
+            async with aiohttp.ClientSession() as session:
+                results = await get_analytics_codes(
+                    session=session,
+                    urls=args.urls,
+                    start_date=args.start_date,
+                    end_date=args.end_date,
+                    frequency=args.frequency,
+                    limit=args.limit,
+                    semaphore=semaphore,
+                    skip_current=args.skip_current,
+                )
+                print(results)
+
+        # handle printing the output
+        if args.output:
+            write_output(output_file, args.output, results)
+    except aiohttp.ClientError as e:
+        print("Your request was rate limited. Wait 5 minutes and try again and consider reducing the limit and # of numbers.")
 
 
 def setup_args():
@@ -95,6 +109,7 @@ def setup_args():
         --end_date: End date for time range. Defaults to None.
         --frequency: Can limit snapshots to remove duplicates (1 per hr, day, month, etc). Defaults to None.
         --limit: Limit number of snapshots returned. Defaults to None.
+        --skip_current: Add this flag to skip current UA/GA codes when getting archived codes.
 
     Returns:
         Command line arguments (argparse)
@@ -147,6 +162,12 @@ def setup_args():
         "--limit",
         default=-100,
         help="Limits number of snapshots returned. Defaults to -100 (most recent 100 snapshots).",
+    )
+    parser.add_argument(
+        "-sc",
+        "--skip_current",
+        action='store_true',
+        help="Add this flag to skip current UA/GA codes when getting archived codes.",
     )
 
     return parser.parse_args()

--- a/wayback_google_analytics/main.py
+++ b/wayback_google_analytics/main.py
@@ -66,16 +66,20 @@ async def main(args):
         )
         args.frequency = COLLAPSE_OPTIONS[args.frequency]
 
-    async with aiohttp.ClientSession() as session:
-        results = await get_analytics_codes(
-            session=session,
-            urls=args.urls,
-            start_date=args.start_date,
-            end_date=args.end_date,
-            frequency=args.frequency,
-            limit=args.limit,
-        )
-        print(results)
+    semaphore = asyncio.Semaphore(15)
+
+    async with semaphore:
+        async with aiohttp.ClientSession() as session:
+            results = await get_analytics_codes(
+                session=session,
+                urls=args.urls,
+                start_date=args.start_date,
+                end_date=args.end_date,
+                frequency=args.frequency,
+                limit=args.limit,
+                semaphore=semaphore,
+            )
+            print(results)
 
     # handle printing the output
     if args.output:
@@ -147,9 +151,11 @@ def setup_args():
 
     return parser.parse_args()
 
+
 def main_entrypoint():
     args = setup_args()
     asyncio.run(main(args))
+
 
 if __name__ == "__main__":
     main_entrypoint()

--- a/wayback_google_analytics/main.py
+++ b/wayback_google_analytics/main.py
@@ -70,11 +70,13 @@ async def main(args):
 
     # Warn user if large request
     if abs(int(args.limit)) > 500 or len(args.urls) > 9:
-        response = input(f"""Large requests can lead to being rate limited by archive.org.\n\n Current limit: {args.limit} (Recommended < 500) \n\n Current # of urls: {len(args.urls)} (Recommended < 10, unless limit < 50)
+        response = input(
+            f"""Large requests can lead to being rate limited by archive.org.\n\n Current limit: {args.limit} (Recommended < 500) \n\n Current # of urls: {len(args.urls)} (Recommended < 10, unless limit < 50)
 
         Do you wish to proceed? (Yes/no)
-                         """)
-        if response.lower() not in ('yes', 'y'):
+                         """
+        )
+        if response.lower() not in ("yes", "y"):
             print("Request cancelled.")
             exit()
 
@@ -97,7 +99,9 @@ async def main(args):
         if args.output:
             write_output(output_file, args.output, results)
     except aiohttp.ClientError as e:
-        print("Your request was rate limited. Wait 5 minutes and try again and consider reducing the limit and # of numbers.")
+        print(
+            "Your request was rate limited. Wait 5 minutes and try again and consider reducing the limit and # of numbers."
+        )
 
 
 def setup_args():
@@ -166,7 +170,7 @@ def setup_args():
     parser.add_argument(
         "-sc",
         "--skip_current",
-        action='store_true',
+        action="store_true",
         help="Add this flag to skip current UA/GA codes when getting archived codes.",
     )
 

--- a/wayback_google_analytics/utils.py
+++ b/wayback_google_analytics/utils.py
@@ -136,3 +136,19 @@ def get_14_digit_timestamp(date):
 
     # Convert datetime object to 14-digit timestamp
     return date.strftime("%Y%m%d%H%M%S")
+
+def generate_semaphore(url_list, limit):
+    """Generates appropriate semaphore given a list of urls and a limit."""
+
+    url_count = len(url_list)
+
+    operations = url_count * limit
+
+    if operations <= 100:
+        return 10
+
+    if operations <= 1000:
+        return 5
+
+    if operations <= 10000:
+        return 1


### PR DESCRIPTION
# Overview

This PR addresses issue #19 and attempts to mitigate some of the 443 errors that result from large queries. It adds a semaphore of 10 in `main.py` that is inherited by functions called thereafter and adds a 5 second delay between each CDX api call when retrieving snapshots. 

The program can handle much larger requests now, but there are still persistent issues when asking for very sizeable requests. As a result, there are now warning messages if a query is larger than 10 urls or asking for more than 500 archived snapshots per url. 

# Changelog

#### API errors
- Added an `asyncio.sleep` in for each task passed into `asyncio.gather()` when processing urls. This helps break up the requests to the CDX api and prevents the rate limiting that was so prevalent previously.
- Semaphore is now shared globally. This stops the runaway # of calls when there were >10 or so urls.

#### Readme
- Added "Limitations & Rate Limits" section to warn against very large queries
- Tweaked directions for running/installing from source

#### New Features
- Added a flag called `--skip_current` - using this flag skips making requests to the current version of the website. This is useful for when you're looking at a large number of dead pages or only want to view historical data.
- Added a warning/confirmation message for large requests. If a user passes >10 urls or a limit of >500, they get a warning message that encourages them to break their query into smaller pieces. 

#### Known issues
- While the CDX api issue is largely taken care of, issues with getting rate limited by web.archive.org itself remain. Most users are unlikely to encounter this when staying within the recommended limits.