### PR TITLE
Fix empty code list bug (closes issue #24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
+
 <a name="readme-top"></a>
-<!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
-
-
-
-<!-- PROJECT SHIELDS -->
-<!--
-*** I'm using markdown "reference style" links for readability.
-*** Reference links are enclosed in brackets [ ] instead of parentheses ( ).
-*** See the bottom of this document for the declaration of the reference variables
-*** for contributors-url, forks-url, etc. This is an optional, concise syntax you may use.
-*** https://www.markdownguide.org/basic-syntax/#reference-style-links
--->
 
 [![Contributors][contributors-shield]][contributors-url]
 [![Forks][forks-shield]][forks-url]
@@ -100,6 +82,8 @@
 
 Wayback Google Analytics is a lightweight tool that gathers current and historic
 Google analytics data (UA, GA and GTM codes) from a collection of website urls.
+
+Read Bellingcat's article about using this tool to uncover disinformation networks online [here](https://www.bellingcat.com/resources/2024/01/09/using-the-wayback-machine-and-google-analytics-to-uncover-disinformation-networks/).
 
 ### Why do I need GA codes?
 
@@ -189,12 +173,12 @@ You can also clone and download the repo from github and use the tool locally.
 
 1. Clone repo:
     ```terminal
-    git clone git@github.com:jclark1913/osint-google-analytics.git
+    git clone git@github.com:bellingcat/wayback-google-analytics.git
     ```
 
 2. Navigate to root, create a venv and install requirements.txt:
     ```terminal
-    cd osint-google-analytics
+    cd wayback-google-analytics
     python -m venv venv
     source venv/bin/activate
     pip install -r requirements.txt
@@ -202,7 +186,7 @@ You can also clone and download the repo from github and use the tool locally.
 
 3. Get a high-level overview:
     ```terminal
-    python -m wayback_google_analytics.main.py -h
+    python -m wayback_google_analytics.main -h
     ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wayback-google-analytics"
-version = "0.2.1"
+version = "0.2.2"
 description = "A tool for gathering current and historic google analytics ids from multiple websites"
 authors = ["Justin Clark <jclarksummit@gmail.com>"]
 license = "MIT"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -304,3 +304,15 @@ class OutputTestCase(TestCase):
 
         self.assertEqual(actual_results.to_dict(orient="records"), expected_results)
         self.assertTrue(type(actual_results) is pd.DataFrame)
+
+    def test_get_codes_df_empty_list(self):
+        """Does get_codes_df return a df with a message if codes_list is empty?"""
+
+        test_results = []
+        expected_results = pd.DataFrame({"Message": ["No codes found."]})
+
+        actual_results = get_codes_df(test_results)
+
+        self.assertEqual(actual_results.to_dict(orient="records"), expected_results.to_dict(orient="records"))
+        self.assertTrue(type(actual_results) is pd.DataFrame)
+

--- a/wayback_google_analytics/output.py
+++ b/wayback_google_analytics/output.py
@@ -175,6 +175,10 @@ def get_codes_df(results):
                             }
                         )
 
+    # Return a df w/ string message if no codes found
+    if not code_list:
+        return pd.DataFrame([{"Message": "No codes found."}])
+
     # Convert list of dicts to pandas dataframe
     codes_df = pd.DataFrame(code_list)
 


### PR DESCRIPTION
### Overview

This PR fixes a bug where queries that didn't find any codes would throw a confusing error. Now, if there are no codes the spreadsheet is generated with a message. 

The fix is just an extra guard statement + a test that makes sure `codes_list` in `get_codes_df` is not empty. If it is, it immediately returns a df with the message. 

This does raise the question: if there are no codes do we even want to write to an output file? I like the idea of returning the usual format, just empty (I think this is helpful if someone  has incorporated the tool and its output into their workflow), but it is worth thinking about changing in a future update.

### Changelog
- `get_codes_df` now returns message if given an empty list of codes
- Added a unit test to verify that `get_codes_df` returns a message if given an empty list of codes
- Updated readme to contain link to recent Bellingcat article about the tool + fixed the "Download from source" section which contained outdated and incorrect instructions.

Closes #24 