### PR TITLE
Change filenames/paths to be cross-platform (fixes #26)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "wayback-google-analytics"
-version = "0.2.2"
+version = "0.2.3"
 description = "A tool for gathering current and historic google analytics ids from multiple websites"
 authors = ["Justin Clark <jclarksummit@gmail.com>"]
 license = "MIT"

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,7 +21,7 @@ class OutputTestCase(TestCase):
 
     def setUp(self):
         """Create test data"""
-        self.test_timestamp = "01-01-2023(12:00:00)"
+        self.test_timestamp = "01-01-2023(12-00-00)"
         self.test_path = "./test_output"
         self.valid_types = ["csv", "txt", "json", "xlsx"]
         if not os.path.exists(self.test_path):
@@ -76,7 +76,7 @@ class OutputTestCase(TestCase):
     def test_init_output_valid_types(self, mock_datetime):
         """Does init_output create a dict with correct keys?"""
         mock_now = Mock(
-            return_value=datetime.strptime(self.test_timestamp, "%d-%m-%Y(%H:%M:%S)")
+            return_value=datetime.strptime(self.test_timestamp, "%d-%m-%Y(%H-%M-%S)")
         )
         mock_datetime.now = mock_now
 

--- a/wayback_google_analytics/output.py
+++ b/wayback_google_analytics/output.py
@@ -26,14 +26,14 @@ def init_output(type, output_dir="./output"):
         os.makedirs(output_dir)
 
     # Get current date and time for file name
-    file_name = datetime.now().strftime("%d-%m-%Y(%H:%M:%S)")
+    file_name = datetime.now().strftime("%d-%m-%Y(%H-%M-%S)")
 
     # Create empty output file if type is not csv and return filename
     if type not in ["csv"]:
         with open(os.path.join(f"{output_dir}", f"{file_name}.{type}"), "w") as f:
             pass
 
-        return f"{output_dir}/" + f"{file_name}.{type}"
+        return os.path.join(output_dir, f"{file_name}.{type}")
 
     # If csv, create separate files for urls and codes and return filename
     with open(os.path.join(f"{output_dir}", f"{file_name}_urls.{type}"), "w") as f:
@@ -42,7 +42,7 @@ def init_output(type, output_dir="./output"):
     with open(os.path.join(f"{output_dir}", f"{file_name}_codes.{type}"), "w") as f:
         pass
 
-    return f"{output_dir}/" + f"{file_name}.{type}"
+    return os.path.join(output_dir, f"{file_name}.{type}")
 
 
 def write_output(output_file, output_type, results):


### PR DESCRIPTION
## Overview

This PR fixes a bug experienced by Windows users (reported in #26 - thanks @martyna1221! ) where filenames generated with colons were throwing an `oserror`. 

This PR makes all file paths compatible with Windows and updates `output_test.py`. 

## Changelog

- Colons (:) are now dashes (i) in filenames
- `os.path` is now used in `output.py` for all filepaths 
- Version bumped to `0.2.3`